### PR TITLE
pins jinja2 version < 3

### DIFF
--- a/conda-env.yml
+++ b/conda-env.yml
@@ -1,4 +1,4 @@
-name: bestpractices
+name: bestpractices3
 channels:
   - conda-forge
   - pytorch
@@ -16,3 +16,4 @@ dependencies:
   - tqdm=4.43.*
   - ipython
   - jupyter
+  - jinja2<3.0

--- a/conda-env.yml
+++ b/conda-env.yml
@@ -1,4 +1,4 @@
-name: bestpractices3
+name: bestpractices
 channels:
   - conda-forge
   - pytorch


### PR DESCRIPTION
This PR pins the version of jinja2 installed in the environment.  The package `pandas_profiling` uses  'escape' from 'jinja2.utils', which is not present in `jinja2` version 3. The environment file as in the original repo results in installation of the latest jinja version.

Tested on Windows 11 and Ubuntu 20.04 (through WSL).

Without pinning, jinja2 version 3.1.2 is installed. With pinning, jinja2 version 2.11.3 is installed.

Output from `0b-check_dependencies.ipynb` without pin:

```[ OK ] numpy version 1.18.5
[ OK ] pandas version 1.0.5
[FAIL] Error in importing pandas_profiling: cannot import name 'escape' from 'jinja2.utils' (/home/janash/miniconda3/envs/bestpractices/lib/python3.7/site-packages/jinja2/utils.py)
[ OK ] matplotlib version 3.2.2
[ OK ] seaborn version 0.10.1
[ OK ] sklearn version 0.22.2.post1
[ OK ] scipy version 1.4.1
[ OK ] tqdm version 4.43.0
[ OK ] jupyter_client version 7.4.9
[ OK ] ipywidgets version 8.0.4
[ OK ] torch version 1.3.1
```

After pinning jinja2:

```[ OK ] numpy version 1.18.5
[ OK ] pandas version 1.0.5
[ OK ] pandas_profiling version 2.8.0
[ OK ] matplotlib version 3.2.2
[ OK ] seaborn version 0.10.1
[ OK ] sklearn version 0.22.2.post1
[ OK ] scipy version 1.4.1
[ OK ] tqdm version 4.43.0
[ OK ] jupyter_client version 7.4.9
[ OK ] ipywidgets version 8.0.4
[ OK ] torch version 1.3.1
```
